### PR TITLE
ExportExaprintSelection Form too many fields

### DIFF
--- a/AdminIncludes/module_configuration.html
+++ b/AdminIncludes/module_configuration.html
@@ -183,26 +183,28 @@
                                                     {/loop}
                                                 </td>
                                                 <td>
-                                                    {assign var="pkgNbRef" value="`$REF|replace:'.':'-'`-pkgNumber"}
-                                                    {form_field form=$form field=$pkgNbRef}
+                                                    {form_field form=$form field="pkgNumber" value_key="{$LOOP_COUNT}"}
                                                         <input class="form-control text-center" style="width:70px; margin:auto;" type="text" name="{$name}" value="1" />
                                                     {/form_field}
                                                 </td>
                                                 <td>
-                                                    {assign var="pkgW8Ref" value="`$REF|replace:'.':'-'`-pkgWeight"}
-                                                    {form_field form=$form field=$pkgW8Ref}
+                                                    {form_field form=$form field="pkgWeight" value_key="{$LOOP_COUNT}"}
                                                         <input class="form-control text-center" style="width:70px; margin:auto;" type="text" name="{$name}" value="0" />
                                                     {/form_field}
                                                 </td>
-                                                {assign var="assurref" value="`$REF|replace:'.':'-'`-assur"}
-                                                {form_field form=$form field=$assurref}
+                                                {form_field form=$form field="assur" value_key="{$LOOP_COUNT}"}
                                                 <td class="text-center">
                                                     <input type="checkbox" name="{$name}" value="true" />
                                                 </td>
                                                 {/form_field}
-                                                {form_field form=$form field=$REF|replace:'.':'-'}
+                                                {form_field form=$form field="order_ref_check" value_key="{$LOOP_COUNT}"}
                                                 <td class="text-center">
-                                                    <input type="checkbox" name="{$name}" id="{$label_attr.for}" value=="true" />
+                                                    <input type="checkbox" name="{$name}" value="true" />
+                                                </td>
+                                                {/form_field}
+                                                {form_field form=$form field="order_ref" value_key="{$LOOP_COUNT}"}
+                                                <td class="text-center">
+                                                    <input type="hidden" name="{$name}" value="{$REF|replace:'.':'-'}" />
                                                 </td>
                                                 {/form_field}
                                             </tr>

--- a/AdminIncludes/order-edit.html
+++ b/AdminIncludes/order-edit.html
@@ -13,7 +13,11 @@
                     <input type="hidden" name="{$name}" value="nochange" />
                 {/form_field}
 
-                {form_field form=$form field={$REF|replace:'.':'-'}}
+                {form_field form=$form field="order_ref" value_key=0}
+                    <input type="hidden" name="{$name}" value="{$REF|replace:'.':'-'}" />
+                {/form_field}
+
+                {form_field form=$form field="order_ref_check" value_key=0}
                     <input type="hidden" name="{$name}" value="true" />
                 {/form_field}
                 <button type="submit" name="export_order" value="stay" class="form-submit-button btn btn-sm btn-default" title="{intl l='Export'}">{intl l='Export'} <span class="glyphicon glyphicon-ok"></span></button>

--- a/Controller/Export.php
+++ b/Controller/Export.php
@@ -169,12 +169,15 @@ class Export extends BaseAdminController
         foreach ($orders as $order) {
             $orderRef = str_replace(".", "-", $order->getRef());
 
-            if ($vform->get($orderRef)->getData()) {
+            $collectionKey = array_search($orderRef, $vform->getData()['order_ref']);
+            if (false !== $collectionKey
+                && array_key_exists($collectionKey, $vform->getData()['order_ref_check'])
+                && $vform->getData()['order_ref_check'][$collectionKey]) {
 
                 // Get if the package is assured, how many packages there are & their weight
-                $assur_package = $vform->get($orderRef . "-assur")->getData();
-                $pkgNumber = $vform->get($orderRef . '-pkgNumber')->getData();
-                $pkgWeight = $vform->get($orderRef . '-pkgWeight')->getData();
+                $assur_package = array_key_exists($collectionKey, $vform->getData()['assur']) ? $vform->getData()['assur'][$collectionKey] : false;
+                $pkgNumber = array_key_exists($collectionKey, $vform->getData()['pkgNumber']) ? $vform->getData()['pkgNumber'][$collectionKey] : null;
+                $pkgWeight = array_key_exists($collectionKey, $vform->getData()['pkgWeight']) ? $vform->getData()['pkgWeight'][$collectionKey] : null;
 
                 // Check if status has to be changed
                 if ($status_id == "processing") {

--- a/Form/ExportExaprintSelection.php
+++ b/Form/ExportExaprintSelection.php
@@ -46,10 +46,6 @@ class ExportExaprintSelection extends BaseForm
             $data = DpdPickup::NO_CHANGE;
         }
 
-        $entries = OrderQuery::create()
-            ->filterByDeliveryModuleId(DpdPickup::getModuleId())
-            ->find();
-
         $this->formBuilder
             ->add(
                 'new_status_id',
@@ -66,34 +62,55 @@ class ExportExaprintSelection extends BaseForm
                     'multiple' => false,
                     'data' => $data
                 )
-            );
+            )
 
-        foreach ($entries as $order) {
-            $orderRef = str_replace(".", "-", $order->getRef());
+            // Collections
 
-            $this->formBuilder
-                ->add(
-                    $orderRef,
-                    'checkbox',
-                    array(
-                        'label' => $orderRef,
-                        'label_attr' => array(
-                            'for' => $orderRef
-                        )
-                    )
+            ->add(
+                'order_ref_check',
+                'collection',
+                array(
+                    'type'         => 'checkbox',
+                    'allow_add'    => true,
+                    'allow_delete' => true,
                 )
-                ->add(
-                    $orderRef . "-assur",
-                    'checkbox'
+            )
+            ->add(
+                'order_ref',
+                'collection',
+                array(
+                    'type'         => 'text',
+                    'allow_add'    => true,
+                    'allow_delete' => true,
                 )
-                ->add(
-                    $orderRef . "-pkgNumber",
-                    'number'
+            )
+            ->add(
+                'assur',
+                'collection',
+                array(
+                    'type'         => 'checkbox',
+                    'allow_add'    => true,
+                    'allow_delete' => true,
                 )
-                ->add(
-                    $orderRef . "-pkgWeight",
-                    'number'
-                );
-        }
+            )
+            ->add(
+                'pkgNumber',
+                'collection',
+                array(
+                    'type'         => 'number',
+                    'allow_add'    => true,
+                    'allow_delete' => true,
+                )
+            )
+            ->add(
+                'pkgWeight',
+                'collection',
+                array(
+                    'type'         => 'number',
+                    'allow_add'    => true,
+                    'allow_delete' => true,
+                )
+            )
+        ;
     }
 }


### PR DESCRIPTION
Previously the form exportexaprintselection had a lot of fields which were unnecessary.
I replaced fields by collections to get a dynamic form.

I applied changes to the templates using the form.
