### PR TITLE
Since Thelia has decimal with precision 6,

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -31,7 +31,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <author>
         <name>Thelia</name>
         <email>info@thelia.net</email>

--- a/DpdPickup.php
+++ b/DpdPickup.php
@@ -192,7 +192,8 @@ class DpdPickup extends AbstractDeliveryModule
             $freeShippingAmount = (float) self::getFreeShippingAmount();
 
             //If a min price for freeShipping is define and the amount of cart reach this montant return 0
-            if ($freeShippingAmount > 0 && $freeShippingAmount <= $cartAmount) {
+            //Be carefull ! Thelia cartAmount is a decimal with 6 in precision ! That's why we must round cart amount
+            if ($freeShippingAmount > 0 && $freeShippingAmount <= round($cartAmount, 2)) {
                 return 0;
             }
 


### PR DESCRIPTION
the freeShipping test is wrong. We must compare a round $cartAmount with $freeShippingAmount